### PR TITLE
Visual Tests > Also show overlay

### DIFF
--- a/e2e/confirm.e2e-spec.ts
+++ b/e2e/confirm.e2e-spec.ts
@@ -16,27 +16,27 @@ describe('Confirm (lg screen)', () => {
 
   it('should match previous OK screenshot', (done) => {
     element(by.css('.sky-confirm-btn-ok')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous YesCancel screenshot', (done) => {
     element(by.css('.sky-confirm-btn-yescancel')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous body screenshot', (done) => {
     element(by.css('.sky-confirm-btn-body')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous YesNoCancel screenshot', (done) => {
     element(by.css('.sky-confirm-btn-yesnocancel')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous custom screenshot', (done) => {
     element(by.css('.sky-confirm-btn-custom')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 });
 
@@ -48,26 +48,26 @@ describe('Confirm (small screen)', () => {
 
   it('should match previous OK screenshot on small screens', (done) => {
     element(by.css('.sky-confirm-btn-ok')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous YesCancel screenshot on small screens', (done) => {
     element(by.css('.sky-confirm-btn-yescancel')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous body screenshot on small screens', (done) => {
     element(by.css('.sky-confirm-btn-body')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous YesNoCancel screenshot on small screens', (done) => {
     element(by.css('.sky-confirm-btn-yesnocancel')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 
   it('should match previous custom screenshot on small screens', (done) => {
     element(by.css('.sky-confirm-btn-custom')).click();
-    expect('.sky-modal').toMatchBaselineScreenshot(done);
+    expect('body').toMatchBaselineScreenshot(done);
   });
 });

--- a/e2e/modal.e2e-spec.ts
+++ b/e2e/modal.e2e-spec.ts
@@ -20,56 +20,56 @@ describe('Modal', () => {
 
     it('should match previous modal screenshot', (done) => {
       element(by.css('.sky-btn-primary')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-screenshot'
       });
     });
 
     it('should match previous modal screenshot with help button in header', (done) => {
       element(by.css('.sky-modal-with-help')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-with-help-screenshot'
       });
     });
 
     it('should match previous screenshot of modal without header or footer', (done) => {
       element(by.css('.sky-test-content-only')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-content-screenshot'
       });
     });
 
     it('should match previous small size modal screenshot', (done) => {
       element(by.css('.sky-test-small-size-modal')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-small-size-screenshot'
       });
     });
 
     it('should match previous medium size modal screenshot', (done) => {
       element(by.css('.sky-test-medium-size-modal')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-medium-size-screenshot'
       });
     });
 
     it('should match previous large modal screenshot', (done) => {
       element(by.css('.sky-test-large-modal')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-large-screenshot'
       });
     });
 
     it('should match previous large size modal screenshot', (done) => {
       element(by.css('.sky-test-large-size-modal')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-large-size-screenshot'
       });
     });
 
     it('should match previous autofocus screenshot', (done) => {
       element(by.css('.sky-test-large-modal-autofocus')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-lg-autofocus-screenshot'
       });
     });
@@ -82,14 +82,14 @@ describe('Modal', () => {
 
     it('should match previous large size modal screenshot on intermediate screens', (done) => {
       element(by.css('.sky-test-large-size-modal')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-md-large-size-screenshot'
       });
     });
 
     it('should match previous tiled modal screenshot', (done) => {
       element(by.css('.sky-test-tiled-modal')).click();
-      expect('.sky-modal').toMatchBaselineScreenshot(done, {
+      expect('body').toMatchBaselineScreenshot(done, {
         screenshotName: 'modal-md-tiled-screenshot'
       });
     });

--- a/src/app/app-extras.module.ts
+++ b/src/app/app-extras.module.ts
@@ -3,33 +3,40 @@ import {
 } from '@angular/core';
 
 import {
+  SkyTilesModule
+} from '@skyux/tiles';
+
+import {
   SkyConfirmModule,
   SkyModalModule,
   SkyModalService
 } from './public';
 
 import {
-  SkyTilesModule
-} from '@skyux/tiles';
-
-import {
   ModalDemoComponent
 } from './visual/modal/modal-demo.component';
+
 import {
   ModalContentDemoComponent
 } from './visual/modal/modal-content-demo.component';
+
 import {
   ModalFullPageDemoComponent
 } from './visual/modal/modal-fullpage-demo.component';
+
 import {
   ModalLargeDemoComponent
 } from './visual/modal/modal-large-demo.component';
+
 import {
   ModalTiledDemoComponent
 } from './visual/modal/modal-tiled-demo.component';
+
 import {
   ModalContentAutofocusComponent
 } from './visual/modal/modal-content-autofocus.component';
+
+require('style-loader!./visual.scss');
 
 @NgModule({
   imports: [

--- a/src/app/visual.scss
+++ b/src/app/visual.scss
@@ -1,0 +1,3 @@
+#skypages-header {
+  display: none;
+}

--- a/src/app/visual/confirm/confirm-visual.component.html
+++ b/src/app/visual/confirm/confirm-visual.component.html
@@ -1,34 +1,36 @@
-<button
-  type="button"
-  class="sky-btn sky-btn-primary sky-confirm-btn-ok"
-  (click)="openOKConfirm()">
-  OK confirm
-</button>
+<div style="height:100vh">
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-confirm-btn-ok"
+    (click)="openOKConfirm()">
+    OK confirm
+  </button>
 
-<button
-  type="button"
-  class="sky-btn sky-btn-primary sky-confirm-btn-yescancel"
-  (click)="openYesCancelConfirm()">
-  Yes/cancel confirm
-</button>
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-confirm-btn-yescancel"
+    (click)="openYesCancelConfirm()">
+    Yes/cancel confirm
+  </button>
 
-<button
-  type="button"
-  class="sky-btn sky-btn-primary sky-confirm-btn-body"
-  (click)="openConfirmWithBody()">
-  Confirm with body
-</button>
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-confirm-btn-body"
+    (click)="openConfirmWithBody()">
+    Confirm with body
+  </button>
 
-<button
-  type="button"
-  class="sky-btn sky-btn-primary sky-confirm-btn-yesnocancel"
-  (click)="openYesNoCancelConfirm()">
-  Yes/no/cancel confirm
-</button>
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-confirm-btn-yesnocancel"
+    (click)="openYesNoCancelConfirm()">
+    Yes/no/cancel confirm
+  </button>
 
-<button
-  type="button"
-  class="sky-btn sky-btn-primary sky-confirm-btn-custom"
-  (click)="openCustomConfirm()">
-  Custom confirm
-</button>
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-confirm-btn-custom"
+    (click)="openCustomConfirm()">
+    Custom confirm
+  </button>
+</div>

--- a/src/app/visual/modal/modal-visual.component.html
+++ b/src/app/visual/modal/modal-visual.component.html
@@ -1,4 +1,4 @@
-<div>
+<div style="height:100vh">
   <button
     type="button"
     class="sky-btn sky-btn-primary"


### PR DESCRIPTION
Using 'body' for the visual tests selector will allow the screenshot to also include the modal overlays (we weren't able to catch a visual change with the backdrop in previous versions).