### PR TITLE
Prevent click events from host bubbling up

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@blackbaud/skyux": "2.38.0",
-    "@blackbaud/skyux-builder": "1.30.0",
-    "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.5"
+    "@blackbaud/skyux": "2.48.0",
+    "@blackbaud/skyux-builder": "1.33.1",
+    "@skyux-sdk/builder-plugin-skyux": "1.0.0"
   }
 }

--- a/src/app/public/modules/modal/modal-host.component.ts
+++ b/src/app/public/modules/modal/modal-host.component.ts
@@ -1,11 +1,12 @@
 import {
+  ChangeDetectorRef,
   Component,
   ComponentFactoryResolver,
+  HostListener,
   Injector,
   ReflectiveInjector,
   ViewChild,
-  ViewContainerRef,
-  ChangeDetectorRef
+  ViewContainerRef
 } from '@angular/core';
 
 import {
@@ -61,6 +62,12 @@ export class SkyModalHostComponent {
     private router: Router,
     private changeDetector: ChangeDetectorRef
   ) { }
+
+  @HostListener('click', ['$event'])
+  public onHostClick(event: any): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
 
   public open(modalInstance: SkyModalInstance, component: any, config?: IConfig) {
     let params: IConfig = Object.assign({}, config);

--- a/src/app/public/modules/modal/modal.component.spec.ts
+++ b/src/app/public/modules/modal/modal.component.spec.ts
@@ -555,4 +555,19 @@ describe('Modal component', () => {
 
     closeModal(modalInstance);
   }));
+
+  it('should prevent click events from bubbling beyond host element', fakeAsync(function () {
+    const modalInstance = openModal(ModalTiledBodyTestComponent);
+
+    let numClicks = 0;
+    document.body.addEventListener('click', function () {
+      numClicks++;
+    });
+
+    SkyAppTestUtility.fireDomEvent(document.querySelector('.sky-modal'), 'click');
+
+    expect(numClicks).toEqual(0);
+
+    closeModal(modalInstance);
+  }));
 });

--- a/src/app/public/modules/modal/modal.component.spec.ts
+++ b/src/app/public/modules/modal/modal.component.spec.ts
@@ -558,15 +558,22 @@ describe('Modal component', () => {
 
   it('should prevent click events from bubbling beyond host element', fakeAsync(function () {
     const modalInstance = openModal(ModalTiledBodyTestComponent);
+    const modalElement = document.querySelector('.sky-modal');
 
-    let numClicks = 0;
-    document.body.addEventListener('click', function () {
-      numClicks++;
+    let numDocumentClicks = 0;
+    document.addEventListener('click', function () {
+      numDocumentClicks++;
     });
 
-    SkyAppTestUtility.fireDomEvent(document.querySelector('.sky-modal'), 'click');
+    let numModalClicks = 0;
+    modalElement.addEventListener('click', function () {
+      numModalClicks++;
+    });
 
-    expect(numClicks).toEqual(0);
+    SkyAppTestUtility.fireDomEvent(modalElement, 'click');
+
+    expect(numDocumentClicks).toEqual(0);
+    expect(numModalClicks).toEqual(1);
 
     closeModal(modalInstance);
   }));


### PR DESCRIPTION
Helps to address flyout closing issues.
See blackbaud/skyux-flyout#26