### PR TITLE
Preserve whitespace/newlines in sky-confirm-body

### DIFF
--- a/src/app/public/modules/confirm/confirm.component.scss
+++ b/src/app/public/modules/confirm/confirm.component.scss
@@ -7,6 +7,7 @@
 
 .sky-confirm-body {
   margin-top: $sky-margin;
+  white-space: pre-wrap;
 }
 
 .sky-confirm-buttons {


### PR DESCRIPTION
The `body` field of the [`Confirm` component](https://developer.blackbaud.com/skyux/components/confirm) is a string that is displayed to the user providing more details to help them make a decision when confirming/denying their intent.

By default, whitespace and newline characters are stripped from this element, making it difficult for developers to communicate ideas / information clearly. Adding in this css style preserves these whitespace/newline characters.

*Before*:
![image](https://user-images.githubusercontent.com/12850455/56759992-31b95500-6768-11e9-875f-f276d1b8d04a.png)

*After*:
![image](https://user-images.githubusercontent.com/12850455/56760066-62998a00-6768-11e9-825c-f3747b02bd41.png)

**Seeking feedback**

I debated between `pre-wrap` and `pre-line`. It is my understanding that `pre-line` will strip consecutive whitespace chars/new line chars down to 1, whereas pre-wrap will keep all whitespace characters. I'm open to either option if this change is something the SKYUX team is willing to consider pulling in.