### PR TITLE
Removed styles that were causing the chevrons on tiles in modals to be wrong

### DIFF
--- a/src/app/public/modules/modal/modal.component.scss
+++ b/src/app/public/modules/modal/modal.component.scss
@@ -54,10 +54,6 @@
   ::ng-deep .sky-tile-title {
     @include sky-subsection-heading();
   }
-
-  ::ng-deep .sky-tile-tools .sky-chevron {
-    margin: 9px ($sky-tile-header-tool-padding - 6) 8px 0;
-  }
 }
 
 .sky-modal-header {


### PR DESCRIPTION
@Blackbaud-ToddRoberts this will need your review. I don't know why these styles existed and they have since the tiled modals were added. If you can find a reason not to remove them then please let me know.