### PR TITLE
removed z-index from sky-modal-content

### DIFF
--- a/src/app/public/modules/modal/modal.component.scss
+++ b/src/app/public/modules/modal/modal.component.scss
@@ -58,7 +58,6 @@
 
 .sky-modal-content {
   background-color: #fff;
-  z-index: 1;
 
   &:focus {
     outline-style: dotted;


### PR DESCRIPTION
Addresses blackbaud/skyux-lookup#39

`z-index: 1` was added in https://github.com/blackbaud/skyux-modals/pull/3

NEEDS LOTS OF MANUAL/INTEGRATION TESTING