### PR TITLE
Remove deprecated confirm option from demos

### DIFF
--- a/src/app/docs/confirm/confirm-docs.component.html
+++ b/src/app/docs/confirm/confirm-docs.component.html
@@ -21,15 +21,6 @@
       aria-haspopup="dialog"
       class="sky-btn sky-btn-default sky-margin-inline-default"
       type="button"
-      (click)="openYesCancelConfirmWithBody()"
-    >
-      Yes/cancel confirm with body
-    </button>
-
-    <button
-      aria-haspopup="dialog"
-      class="sky-btn sky-btn-default sky-margin-inline-default"
-      type="button"
       (click)="openCustomConfirm()"
     >
       Custom confirm

--- a/src/app/public/plugin-resources/code-examples/confirm/confirm-demo.component.html
+++ b/src/app/public/plugin-resources/code-examples/confirm/confirm-demo.component.html
@@ -13,14 +13,6 @@
     aria-haspopup="dialog"
     class="sky-btn sky-btn-default sky-margin-inline-default"
     type="button"
-    (click)="openYesCancelConfirmWithBody()">
-    Yes/cancel confirm with body
-  </button>
-
-  <button
-    aria-haspopup="dialog"
-    class="sky-btn sky-btn-default sky-margin-inline-default"
-    type="button"
     (click)="openCustomConfirm()">
     Custom confirm
   </button>

--- a/src/app/public/plugin-resources/code-examples/confirm/confirm-demo.component.ts
+++ b/src/app/public/plugin-resources/code-examples/confirm/confirm-demo.component.ts
@@ -35,19 +35,6 @@ export class ConfirmDemoComponent {
     });
   }
 
-  public openYesCancelConfirmWithBody() {
-    const dialog: SkyConfirmInstance = this.confirmService.open({
-      message: 'Use the YesCancel button type to let users confirm or cancel.',
-      body: 'Do not use a YesCancel button type if users could be confused about what the Yes button does. Use a Custom button type instead and provide labels that clearly indicate the action occurs when users select the button.',
-      type: SkyConfirmType.YesCancel
-    });
-
-    dialog.closed.subscribe((result: any) => {
-      this.selectedText = undefined;
-      this.selectedAction = result.action;
-    });
-  }
-
   public openCustomConfirm() {
     const buttons = [
       { text: 'Save', action: 'save', styleType: 'primary' },


### PR DESCRIPTION
We updated the confirm component guidance for button labels and deprecated the options for Yes/No button labels, but we did not remove the Yes/No example from the demo or Stackblitz. This PR removes those demos to avoid confusion, which came up recently. 